### PR TITLE
Fix problems with hash.destroy

### DIFF
--- a/lib/heroku/bouncer.rb
+++ b/lib/heroku/bouncer.rb
@@ -76,24 +76,28 @@ class Heroku::Bouncer < Sinatra::Base
 
   # something went wrong
   get '/auth/failure' do
-    session.destroy
+    destroy_session
     redirect to("/")
   end
 
   # logout, single sign-on style
   get '/auth/sso-logout' do
-    session.destroy
+    destroy_session
     auth_url = ENV["HEROKU_AUTH_URL"] || "https://id.heroku.com"
     redirect to("#{auth_url}/logout")
   end
 
   # logout but only locally
   get '/auth/logout' do
-    session.destroy
+    destroy_session
     redirect to("/")
   end
 
 private
+
+  def destroy_session
+    session = nil if session
+  end
 
   def extract_option(options, option, default = nil)
     options.has_key?(option) ? options[option] : default


### PR DESCRIPTION
I've been seeing errors on Health-report that show session.destroy as failing:

```
NoMethodError: undefined method `destroy' for {}:Hash
```

This fixes that and the errors go away
