### PR TITLE
Sync sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ use Heroku::Bouncer,
   secret: ENV['HEROKU_BOUNCER_SECRET']
 ```
 
-There are 5 additional options you can pass to the middleware:
+There are 6 additional options you can pass to the middleware:
 
 * `oauth[:scope]`: The [OAuth scope][] to use when requesting the OAuth
   token. Default: `identity`.
@@ -101,6 +101,7 @@ There are 5 additional options you can pass to the middleware:
   Default: `true`
 * `expose_user`: Expose the user attributes in the session. Default:
   `true`
+* `session_sync_nonce`: If present, determines the name of a cookie shared across properties under a same domain in order to keep their sessions synchronized. Default: `nil`
 
 
 You use these by passing a hash to the `use` call, for example:


### PR DESCRIPTION
This PR synchronizes sessions across properties by preventing `session_nonce` mismatches. This can be useful in the following scenarios:

Scenario 1:
- User logs into property A
- User visits property B
  The user gets automatically logged into B with the same account used on A

Scenario 2:
- User logs into property A with account X
- User visits property B (as seen above, gets logged into B with account X)
- User logs out from B and logs into B with a different account Y
- User visits property A
  The user gets automatically logged into A with the account Y (the previous session corresponding to account X gets closed)

Scenario 3:
- User logs into property A
- User visits property B (as seen above, gets logged into B with account X)
- User logs out from property B
- User visits property A
  The user gets automatically logged out from property A too
