### PR TITLE
Allow anonymous

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ use Heroku::Bouncer,
   secret: ENV['HEROKU_BOUNCER_SECRET']
 ```
 
-There are 6 additional options you can pass to the middleware:
+There are 7 additional options you can pass to the middleware:
 
 * `oauth[:scope]`: The [OAuth scope][] to use when requesting the OAuth
   token. Default: `identity`.
@@ -102,6 +102,7 @@ There are 6 additional options you can pass to the middleware:
 * `expose_user`: Expose the user attributes in the session. Default:
   `true`
 * `session_sync_nonce`: If present, determines the name of a cookie shared across properties under a same domain in order to keep their sessions synchronized. Default: `nil`
+* `allow_anonymous`: Accepts a lambda that gets called with each request. If the lambda evals to true, the request will not enforce authentication (e.g: `allow_anonymous: lambda { |req| !/\A\/admin/.match(req.fullpath) }` will allow anonymous requests except those with under the `/admin` path). Default: `nil`, which does not allow anonymous access to any URL.
 
 
 You use these by passing a hash to the `use` call, for example:


### PR DESCRIPTION
This PR adds the ability to not enforce authentication on certain requests, which can be configured dynamically with a new optional configuration.

Examples:

```
# Allow anonymous requests to a full site
allow_anonymous: lambda { |_| true }

# Allow anonymous requests to a full site except paths under /admin*
allow_anonymous: lambda { |req| !/\A\/admin/.match(req.fullpath) }

# Allow anonymous requests to the root page, requiring authentication anywhere else
allow_anonymous: lambda { |req| req.fullpath == '/' }
```

This PR includes [PR#17](https://github.com/heroku/heroku-bouncer/pull/17) because both should work great together in public-facing sites: syncing sessions when possible to provide a more consistent UX) but not requiring authentication unless it's really needed. I'll close PR#17 in favor of this one.
