### PR TITLE
Allow an SSL verification override for testing purposes.

### DIFF
--- a/lib/heroku/bouncer/middleware.rb
+++ b/lib/heroku/bouncer/middleware.rb
@@ -157,6 +157,9 @@ private
   end
 
   def fetch_user(token)
+    silence_warnings do
+      OpenSSL::SSL.const_set(:VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE) if ENV.has_key?("HEROKU_API_SSL_VERIFY_NONE")
+    end
     ::Heroku::Bouncer::JsonParser.call(
       Faraday.new(ENV["HEROKU_API_URL"] || "https://api.heroku.com/").get('/account') do |r|
         r.headers['Accept'] = 'application/json'
@@ -207,4 +210,11 @@ private
     return_to.to_s
   end
 
+  def silence_warnings(&block)
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    result = block.call
+    $VERBOSE = warn_level
+    result
+  end
 end


### PR DESCRIPTION
For testing purposes, SSL verification needs to be skipped. This change skips SSL verification only if the `HEROKU_API_SSL_VERIFY_NONE` environment variable is set. In addition, warnings are silenced for the OpenSSL override.

@wuputah can you review?
