### PR TITLE
Update to Sinatra 2.0 dependency for Rails 5

### DIFF
--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_runtime_dependency("omniauth-heroku", "~> 0.1")
-  s.add_runtime_dependency("sinatra", "~> 1.0")
+  s.add_runtime_dependency("sinatra", "~> 2.0")
   s.add_runtime_dependency("faraday", "~> 0.8")
   s.add_runtime_dependency("rack", "~> 1.0")
 


### PR DESCRIPTION
Updates for Rails 5.

Just testing at the moment.  No idea on backwards compatibility.
