### PR TITLE
Loosen faraday constraint

### DIFF
--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name = %q{heroku-bouncer}
+  s.name = "heroku-bouncer"
   s.version = "0.8.0"
 
   s.authors = ["Jonathan Dance"]
@@ -24,12 +24,12 @@ Gem::Specification.new do |s|
     "Gemfile",
     "Rakefile",
   ])
-  s.license = 'MIT'
+  s.license = "MIT"
   s.required_ruby_version = ">= 2.2"
 
   s.add_runtime_dependency("omniauth-heroku", "~> 0.1")
   s.add_runtime_dependency("sinatra", ">= 1.0", "< 3")
-  s.add_runtime_dependency("faraday", "~> 0.8")
+  s.add_runtime_dependency("faraday", ">= 0.8", "< 2")
   s.add_runtime_dependency("rack", ">= 1.0", "< 3")
 
   s.add_development_dependency("rake", "~> 10.0")

--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake", "~> 10.0")
   s.add_development_dependency("minitest", "~> 5.0")
   s.add_development_dependency("minitest-spec-context", "~> 0.0")
-  s.add_development_dependency("rack-test", "~> 0.6")
+  s.add_development_dependency("rack-test", "~> 1.1")
   s.add_development_dependency("mocha", "~> 1.1")
   s.add_development_dependency("delorean", "~> 2.1")
 end


### PR DESCRIPTION
I'd like to loosen the restriction to allow newer Faraday releases, while preventing any potential breaking changes (per SemVer) for `v2.x`

We've been running on Faraday `0.17.x` for years w/o issue. I audited the Faraday [CHANGELOG](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md) for the `1.x` series and don't see any breaking changes that should impact heroku-bouncer.