### PR TITLE
Run against Ruby 2.2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, 3.0 ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ requires Heroku OAuth on all requests.
 
 ## Ruby and Rack compatibility
 
-* **Ruby**: Versions >= 0.8.0 require Ruby >= 2.2. If you need a version
-  that works with prior versions of Ruby, please use version `~> 0.7.1`.
-  Note, however, that 0.7.1 does not support Rack 2 (Rails 5).
+* **Ruby**: Versions `>= 0.8.0` require Ruby >= 2.2.
+  If you need a version that works with prior versions of Ruby, please use version `~> 0.7.1`.
+  Note, however, that `0.7.1` does not support Rack 2 (Rails 5+).
 
 * **Rack**: Rack 1 and 2 are supported.
 


### PR DESCRIPTION
Since we officially support Ruby >= 2.2, we ought to test it too.

To be clear, I'm 💯 on board with also dropping "official" support for EoL'd Rubbies, but until we decide to do that (via a new version bump, at least), we should be sure to test the older ones we claim to support.