### PR TITLE
Support OmniAuth 2 via Newer omniauth-heroku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* #68: Loosen `omniauth-heroku` constraint, allowing `>= 0.1, < 2`, 
+  enabling support of OmniAuth 2. @stevenharman
+* #66: Loosen Faraday constraints, allowing `>= 0.8", < 2`. @stevenharman
+
 # 0.8.0
 
 * #55: Ruby >= 2.4 support and Ruby <2.2 deprecation. Thanks @maxbeizer!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 * #68: Loosen `omniauth-heroku` constraint, allowing `>= 0.1, < 2`, 
-  enabling support of OmniAuth 2. @stevenharman
+  enabling support of OmniAuth 2. This also adds the new [`:login_path`
+  option](README#prompt-to-login). @stevenharman
 * #66: Loosen Faraday constraints, allowing `>= 0.8", < 2`. @stevenharman
 
 # 0.8.0

--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.required_ruby_version = ">= 2.2"
 
-  s.add_runtime_dependency("omniauth-heroku", "~> 0.1")
+  s.add_runtime_dependency("omniauth-heroku", [">= 0.1", "< 2"])
   s.add_runtime_dependency("sinatra", ">= 1.0", "< 3")
   s.add_runtime_dependency("faraday", ">= 0.8", "< 2")
   s.add_runtime_dependency("rack", ">= 1.0", "< 3")

--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -37,5 +37,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest-spec-context", "~> 0.0")
   s.add_development_dependency("rack-test", "~> 1.1")
   s.add_development_dependency("mocha", "~> 1.1")
+  # We need to allow older Nokogiri b/c newer versions require newer Rubies.
+  # Consider bumping this when we drop older Ruby support.
+  s.add_development_dependency("nokogiri", "~> 1.9")
   s.add_development_dependency("delorean", "~> 2.1")
 end

--- a/lib/heroku/bouncer/builder.rb
+++ b/lib/heroku/bouncer/builder.rb
@@ -1,5 +1,6 @@
 require 'heroku/bouncer/middleware'
 require 'rack/builder'
+require 'rack/protection'
 require 'omniauth-heroku'
 
 class Heroku::Bouncer::Builder
@@ -8,6 +9,7 @@ class Heroku::Bouncer::Builder
     builder = Rack::Builder.new
     id, secret, scope = extract_options!(options)
     unless options[:disabled]
+      builder.use Rack::Protection
       builder.use OmniAuth::Builder do
         provider :heroku, id, secret, :scope => scope
       end

--- a/lib/heroku/bouncer/middleware.rb
+++ b/lib/heroku/bouncer/middleware.rb
@@ -20,6 +20,7 @@ class Heroku::Bouncer::Middleware < Sinatra::Base
       # super is not called; we're not using sinatra if we're disabled
     else
       super(app)
+      @disabled = false
       @cookie_secret = extract_option(options, :secret, SecureRandom.hex(64))
       @allow_if_user = extract_option(options, :allow_if_user, nil)
       @redirect_url = extract_option(options, :redirect_url, 'https://www.heroku.com')

--- a/lib/heroku/bouncer/views/login.erb
+++ b/lib/heroku/bouncer/views/login.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Login with Heroku</title>
+    <%# Avoid extra requests for favicon.ico %>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  </head>
+  <body class="heroku_bouncer">
+    <form method="post" action="/auth/heroku" class="heroku_bouncer-login_form">
+      <input type="hidden" name="authenticity_token" value="<%= authenticity_token %>">
+      <button type="submit">Login with Heroku</button>
+    </form>
+  </body>
+</html>

--- a/test/default_config_test.rb
+++ b/test/default_config_test.rb
@@ -14,10 +14,10 @@ describe Heroku::Bouncer do
     end
 
     context "on any request not related with authentication" do
-      it "requires authentication via /auth/heroku, which gets managed by omniauth-heroku" do
+      it "requires authentication via /auth/login, which gets managed by omniauth-heroku" do
         get '/hi'
         assert 302, last_response.status
-        assert_equal "http://#{app_host}/auth/heroku", last_response.location
+        assert_equal "http://#{app_host}/auth/login", last_response.location
       end
 
       context "after a successful OAuth dance" do
@@ -46,11 +46,9 @@ describe Heroku::Bouncer do
 
           # requires authentication
           get '/hi'
-          assert 302, last_response.status
-          assert_equal "http://#{app_host}/auth/heroku", last_response.location
-
           follow_successful_oauth!
           assert_redirected_to_path('/hi')
+
           follow_redirect!
           assert_equal 'hi', last_response.body
         end
@@ -63,7 +61,7 @@ describe Heroku::Bouncer do
         it "redirects to /auth/heroku and after a successful authentication comes back to the given 'return_to'" do
           @return_to = 'http://example.org/foo'
           get '/auth/login', 'return_to' => @return_to
-          follow_successful_oauth!
+          submit_successful_oauth!
           assert_equal @return_to, last_response.location
         end
       end
@@ -72,7 +70,7 @@ describe Heroku::Bouncer do
         it "'return_to' gets ignored and the user gets redirected to the root path" do
           @return_to = 'http://google.com/foo'
           get '/auth/login', 'return_to' => @return_to
-          follow_successful_oauth!
+          submit_successful_oauth!
           assert_equal 'http://example.org/foo', last_response.location
         end
       end
@@ -81,7 +79,7 @@ describe Heroku::Bouncer do
         it "'return_to' gets ignored and the user gets redirected to the root path" do
           @return_to = 'http://example.org/' + ('f' * 255)
           get '/auth/login', 'return_to' => @return_to
-          follow_successful_oauth!
+          submit_successful_oauth!
           assert_equal 'http://example.org/', last_response.location
         end
       end
@@ -89,7 +87,7 @@ describe Heroku::Bouncer do
       context "when there is no 'return_to'" do
         it "redirects to the root path" do
           get '/auth/login'
-          follow_successful_oauth!
+          submit_successful_oauth!
           assert_equal 'http://example.org/', last_response.location
         end
       end

--- a/test/login_path_test.rb
+++ b/test/login_path_test.rb
@@ -1,0 +1,50 @@
+require_relative "test_helper"
+
+describe Heroku::Bouncer do
+  include Rack::Test::Methods
+
+  context "login_path" do
+    it "redirects unauthenticated requests to the default login path" do
+      @app = app_with_bouncer
+
+      get "/hi"
+      assert 302, last_response.status
+      assert_equal "http://#{app_host}/auth/login", last_response.location
+    end
+
+    context "with a custom login path" do
+      before do
+        @app = app_with_bouncer do
+          {login_path: "/custom/login"}
+        end
+
+        app.get("/custom/login") do
+          <<-HTML
+            <!DOCTYPE html>
+            <html lang="en">
+              <body>
+                <form method="post" action="/auth/heroku">
+                  <input type="hidden" name="authenticity_token" value="#{request.env["rack.session"]["csrf"]}">
+                <button type="submit">Do it!</button>
+              </body>
+            </html>
+          HTML
+        end
+      end
+
+      it "redirects unauthenticated requests to the custom path" do
+        get "/hi"
+        assert 302, last_response.status
+        assert_equal "http://#{app_host}/custom/login", last_response.location
+      end
+
+      it "completes the OAuth dance" do
+        get "/hi"
+        follow_redirect!
+        submit_successful_oauth!
+
+        assert_redirected_to_path("/hi")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We recently cut [`omniauth-heroku` version `1.0.0`](https://github.com/heroku/omniauth-heroku/blob/main/CHANGELOG.md#100-2021-07-14) which supports OmniAuth 2, which closes some CVEs. This loosens our constraint on `omniauth-heroku` so we can update too!