### PR TITLE
Use built-in cookie decryption

### DIFF
--- a/test/skip_test.rb
+++ b/test/skip_test.rb
@@ -31,8 +31,10 @@ describe Heroku::Bouncer do
     private
 
     def decode_cookie(raw_cookie)
-      unescaped_cookie = URI::Parser.new.unescape(raw_cookie.split("\n").join)
-      Marshal.load(Base64.decode64(unescaped_cookie.split("--").first))
+      @encryptor ||= Rack::Session::Encryptor.new(default_bouncer_config.fetch(:secret))
+      @encryptor.decrypt(raw_cookie)
+    rescue Rack::Session::Encryptor::InvalidSignature
+      {}
     end
   end
 end


### PR DESCRIPTION
The tests rely on decrypting the cookie to perform assertions on its content.

The current implementation manually implements a version compatible with older versions of Rack::Session. We want to use the built-in way to decrypt the cookie.

(This fixes an error running tests locally.)