### PR TITLE
Add explicit dependency on OpenStruct gem

### DIFF
--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest-spec-context", "~> 0.0")
   s.add_development_dependency("mocha", "~> 2.2")
   s.add_development_dependency("nokogiri", "~> 1.16.4")
+  s.add_development_dependency("ostruct", "~> 0.6.1")
   s.add_development_dependency("rack-test", "~> 2")
   s.add_development_dependency("rake", "~> 13.2.1")
 end

--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -27,16 +27,16 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.required_ruby_version = ">= 3.1"
 
-  s.add_runtime_dependency("omniauth-heroku", [">= 0.1", "< 2"])
-  s.add_runtime_dependency("sinatra", ">= 3.0", "< 4")
   s.add_runtime_dependency("faraday", ">= 2.0.1", "< 3")
+  s.add_runtime_dependency("omniauth-heroku", [">= 0.1", "< 2"])
   s.add_runtime_dependency("rack", ">= 2.0", "< 4")
+  s.add_runtime_dependency("sinatra", ">= 3.0", "< 4")
 
-  s.add_development_dependency("rake", "~> 13.2.1")
+  s.add_development_dependency("delorean", "~> 2.1")
   s.add_development_dependency("minitest", "~> 5.0")
   s.add_development_dependency("minitest-spec-context", "~> 0.0")
-  s.add_development_dependency("rack-test", "~> 2")
   s.add_development_dependency("mocha", "~> 2.2")
   s.add_development_dependency("nokogiri", "~> 1.16.4")
-  s.add_development_dependency("delorean", "~> 2.1")
+  s.add_development_dependency("rack-test", "~> 2")
+  s.add_development_dependency("rake", "~> 13.2.1")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,13 +4,13 @@ ENV['RACK_ENV'] = 'test'
 require 'bundler/setup'
 Bundler.require(:default, :test)
 
+require 'delorean'
+require 'minitest-spec-context'
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'minitest-spec-context'
-require 'rack/test'
 require 'mocha/minitest'
 require 'nokogiri'
-require 'delorean'
+require 'rack/test'
 
 # seed the environment
 ENV['HEROKU_AUTH_URL'] = 'https://auth.example.org'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require 'minitest/autorun'
 require 'minitest/spec'
 require 'mocha/minitest'
 require 'nokogiri'
+require 'ostruct'
 require 'rack/test'
 
 # seed the environment


### PR DESCRIPTION
The OpenStruct gem is going away as a default gem in Ruby 3.5.0 and we're missing a `require` statement.

As we use this in the tests, we need an explicit dependency.

(This fixes an error running tests locally.)