### PR TITLE
Loosen Sinatra version constraint

### DIFF
--- a/heroku-bouncer.gemspec
+++ b/heroku-bouncer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("faraday", ">= 2.0.1", "< 3")
   s.add_runtime_dependency("omniauth-heroku", [">= 0.1", "< 2"])
   s.add_runtime_dependency("rack", ">= 2.0", "< 4")
-  s.add_runtime_dependency("sinatra", ">= 3.0", "< 4")
+  s.add_runtime_dependency("sinatra", ">= 3.0", "< 5")
 
   s.add_development_dependency("delorean", "~> 2.1")
   s.add_development_dependency("minitest", "~> 5.0")

--- a/test/skip_test.rb
+++ b/test/skip_test.rb
@@ -38,10 +38,10 @@ describe Heroku::Bouncer do
         {}
       end
     else
-    def decode_cookie(raw_cookie)
-      unescaped_cookie = URI::Parser.new.unescape(raw_cookie.split("\n").join)
-      Marshal.load(Base64.decode64(unescaped_cookie.split("--").first))
-    end
+      def decode_cookie(raw_cookie)
+        unescaped_cookie = URI::Parser.new.unescape(raw_cookie.split("\n").join)
+        Marshal.load(Base64.decode64(unescaped_cookie.split("--").first))
+      end
     end
   end
 end

--- a/test/skip_test.rb
+++ b/test/skip_test.rb
@@ -30,9 +30,18 @@ describe Heroku::Bouncer do
 
     private
 
+    if defined?(::Rack::Session::Encryptor)
+      def decode_cookie(raw_cookie)
+        @encryptor ||= Rack::Session::Encryptor.new(default_bouncer_config.fetch(:secret))
+        @encryptor.decrypt(raw_cookie)
+      rescue Rack::Session::Encryptor::InvalidSignature
+        {}
+      end
+    else
     def decode_cookie(raw_cookie)
       unescaped_cookie = URI::Parser.new.unescape(raw_cookie.split("\n").join)
       Marshal.load(Base64.decode64(unescaped_cookie.split("--").first))
+    end
     end
   end
 end


### PR DESCRIPTION
This loosens the version constraint in order to the latest major release of Sinatra (and reintroduces #74 in a slightly altered version for compatibility).

According to [GHSA-hxx2-7vcw-mqr3](https://github.com/advisories/GHSA-hxx2-7vcw-mqr3), all versions prior to Sinatra 4.1.0 are vulnerable to [CVE-2024-21510](https://nvd.nist.gov/vuln/detail/CVE-2024-21510).